### PR TITLE
Add Contact Edit Button to Contact Sheet View

### DIFF
--- a/FollowUp.xcodeproj/project.pbxproj
+++ b/FollowUp.xcodeproj/project.pbxproj
@@ -100,7 +100,9 @@
 		210DC6BE2C25B82100B20544 /* View+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DC68C2C25B82100B20544 /* View+Additions.swift */; };
 		210DC6BF2C25B82100B20544 /* ContactsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 210DC68E2C25B82100B20544 /* ContactsInteractor.swift */; };
 		216CF6262C5E18FA00F6EA9F /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 216CF6252C5E18FA00F6EA9F /* Localizable.xcstrings */; };
+		2193DA222C94454C0080C72C /* CNContact+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2193DA212C94454C0080C72C /* CNContact+Additions.swift */; };
 		21A031902C667C5700BF04D8 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 21A0318F2C667C5700BF04D8 /* InfoPlist.xcstrings */; };
+		21F690A12C8B63B9001F127B /* NativeContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21F690A02C8B63B9001F127B /* NativeContactView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -212,7 +214,9 @@
 		210DC68E2C25B82100B20544 /* ContactsInteractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactsInteractor.swift; sourceTree = "<group>"; };
 		210DC6C02C25BBFA00B20544 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		216CF6252C5E18FA00F6EA9F /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		2193DA212C94454C0080C72C /* CNContact+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CNContact+Additions.swift"; sourceTree = "<group>"; };
 		21A0318F2C667C5700BF04D8 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		21F690A02C8B63B9001F127B /* NativeContactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeContactView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -342,6 +346,7 @@
 				210DC6162C25B7F900B20544 /* ContactCardView.swift */,
 				210DC6172C25B7F900B20544 /* ContactSheetView.swift */,
 				210DC6182C25B7F900B20544 /* DateMetView.swift */,
+				21F690A02C8B63B9001F127B /* NativeContactView.swift */,
 			);
 			path = ContactSheet;
 			sourceTree = "<group>";
@@ -525,6 +530,7 @@
 				210DC6892C25B82100B20544 /* Sequence+Additions.swift */,
 				210DC68A2C25B82100B20544 /* String+Additions.swift */,
 				210DC68C2C25B82100B20544 /* View+Additions.swift */,
+				2193DA212C94454C0080C72C /* CNContact+Additions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -702,6 +708,7 @@
 				210DC6B12C25B82100B20544 /* Assertion+Additions.swift in Sources */,
 				210DC6B22C25B82100B20544 /* Color+Additions.swift in Sources */,
 				210DC6542C25B80D00B20544 /* ContactSection.swift in Sources */,
+				21F690A12C8B63B9001F127B /* NativeContactView.swift in Sources */,
 				210DC6432C25B7F900B20544 /* TagsCarouselView.swift in Sources */,
 				210DC6A92C25B82100B20544 /* Log.swift in Sources */,
 				210DC6B52C25B82100B20544 /* EnvironmentValues+Additions.swift in Sources */,
@@ -746,6 +753,7 @@
 				210DC64F2C25B7F900B20544 /* HighlightsTabView.swift in Sources */,
 				210DC6A82C25B82100B20544 /* Tag.swift in Sources */,
 				210DC6402C25B7F900B20544 /* IndividualFeatureView.swift in Sources */,
+				2193DA222C94454C0080C72C /* CNContact+Additions.swift in Sources */,
 				210DC6B72C25B82100B20544 /* Int+Additions.swift in Sources */,
 				210DC6A02C25B82100B20544 /* FollowUpManager.swift in Sources */,
 				210DC6372C25B7F900B20544 /* ActionButtonGridView.swift in Sources */,

--- a/FollowUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FollowUp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ksemianov/WrappingHStack",
       "state" : {
-        "revision" : "2638bc5258607e8a32f2e5675d075896c2401678",
-        "version" : "0.1.3"
+        "revision" : "3300f68b6bf5f8a75ee7ca8a40f136a558053d10",
+        "version" : "0.2.0"
       }
     }
   ],

--- a/FollowUp/Common/Constant.swift
+++ b/FollowUp/Common/Constant.swift
@@ -64,6 +64,8 @@ enum Constant {
         case email = "envelope.fill"
         case minus = "minus"
         case partyPopper = "party.popper.fill"
+        case pencil = "pencil"
+        case personWithAtSymbol = "person.crop.square.filled.and.at.rectangle.fill"
         case personWithCheckmark = "person.crop.circle.fill.badge.checkmark"
         case personWithClock = "person.badge.clock.fill"
         case personWithDescription = "person.text.rectangle.fill"
@@ -92,7 +94,7 @@ enum Constant {
 
         var kind: Kind {
             switch self {
-            case .bolt, .chatBubbles, .chatWithElipses, .chatWithWaveform, .checkmark, .chevronRight, .clock, .closeOutline, .close, .email, .minus, .partyPopper, .personWithCheckmark, .personWithClock, .personWithDescription, .phone, .plus, .settings, .sms, .star, .starWithText, .slashedStar, .target, .thumbsUp, .trash, .arrowCirclePath, .lock, .lockWithExclamationMark: return .sfSymbol
+            case .bolt, .chatBubbles, .chatWithElipses, .chatWithWaveform, .checkmark, .chevronRight, .clock, .closeOutline, .close, .email, .minus, .partyPopper, .pencil, .personWithAtSymbol, .personWithCheckmark, .personWithClock, .personWithDescription, .phone, .plus, .settings, .sms, .star, .starWithText, .slashedStar, .target, .thumbsUp, .trash, .arrowCirclePath, .lock, .lockWithExclamationMark: return .sfSymbol
             case .whatsApp: return .asset
             }
         }

--- a/FollowUp/Common/Mock.swift
+++ b/FollowUp/Common/Mock.swift
@@ -5,6 +5,7 @@
 //  Created by Aaron Baw on 09/10/2021.
 //
 
+import Contacts
 import Fakery
 import Foundation
 import RealmSwift
@@ -30,6 +31,7 @@ final class MockedContact: Object, Contactable {
     @Persisted var containedInFollowUps: Bool = faker.number.randomBool()
     @Persisted var followUpFrequency: FollowUpFrequency? = .daily
     @Persisted var lastInteractedWith: Date? = faker.date.backward(days: 10)
+    var cnContactForNativeContactView: CNContact? = nil
 
     
     convenience init(id: ContactID = UUID().uuidString, name: String = faker.name.name(), phoneNumber: PhoneNumber? = .mocked, email: String? = faker.internet.email(), thumbnailImage: UIImage? = nil, note: String? = faker.hobbit.quote(), followUps: Int = faker.number.randomInt(min: 0, max: 10), createDate: Date = faker.date.backward(days: 30), lastFollowedUp: Date? = faker.date.backward(days: faker.number.randomInt(min: 0, max: 1)), highlighted: Bool = faker.number.randomBool(), containedInFollowUps: Bool = faker.number.randomBool(), lastInteractedWith: Date? = faker.date.backward(days: 10)) {

--- a/FollowUp/Common/Mock.swift
+++ b/FollowUp/Common/Mock.swift
@@ -5,7 +5,6 @@
 //  Created by Aaron Baw on 09/10/2021.
 //
 
-import Contacts
 import Fakery
 import Foundation
 import RealmSwift
@@ -31,7 +30,6 @@ final class MockedContact: Object, Contactable {
     @Persisted var containedInFollowUps: Bool = faker.number.randomBool()
     @Persisted var followUpFrequency: FollowUpFrequency? = .daily
     @Persisted var lastInteractedWith: Date? = faker.date.backward(days: 10)
-    var cnContactForNativeContactView: CNContact? = nil
 
     
     convenience init(id: ContactID = UUID().uuidString, name: String = faker.name.name(), phoneNumber: PhoneNumber? = .mocked, email: String? = faker.internet.email(), thumbnailImage: UIImage? = nil, note: String? = faker.hobbit.quote(), followUps: Int = faker.number.randomInt(min: 0, max: 10), createDate: Date = faker.date.backward(days: 30), lastFollowedUp: Date? = faker.date.backward(days: faker.number.randomInt(min: 0, max: 1)), highlighted: Bool = faker.number.randomBool(), containedInFollowUps: Bool = faker.number.randomBool(), lastInteractedWith: Date? = faker.date.backward(days: 10)) {

--- a/FollowUp/Extensions/CNContact+Additions.swift
+++ b/FollowUp/Extensions/CNContact+Additions.swift
@@ -1,0 +1,15 @@
+//
+//  CNContact+Additions.swift
+//  FollowUp
+//
+//  Created by Aaron Baw on 13/09/2024.
+//
+
+import Contacts
+import Foundation
+
+extension CNContact {
+    func toContact() -> Contact {
+        Contact(from: self)
+    }
+}

--- a/FollowUp/Extensions/String+Additions.swift
+++ b/FollowUp/Extensions/String+Additions.swift
@@ -24,3 +24,7 @@ extension String {
         self.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
+
+extension String: Identifiable {
+    public var id: String { self }
+}

--- a/FollowUp/Mock/MockContactInteractor.swift
+++ b/FollowUp/Mock/MockContactInteractor.swift
@@ -41,6 +41,10 @@ class MockContactsInteractor: ContactsInteracting, ObservableObject {
     func fetchContacts() {
         self.contacts.append(contentsOf: generateContacts(withCount: 10))
     }
+    
+    func updateContactInStore(withCNContactID ID: ContactID) {
+        
+    }
 
     private func generateContacts(withCount count: Int) -> [any Contactable] {
         (0...count).map { _ in MockedContact() }

--- a/FollowUp/Mock/MockContactInteractor.swift
+++ b/FollowUp/Mock/MockContactInteractor.swift
@@ -13,11 +13,11 @@ class MockContactsInteractor: ContactsInteracting, ObservableObject {
     
     @Published var contactSheet: ContactSheet?
 
-    @Published var contacts: [any Contactable] = []
+    @Published var contacts: ContactSignal = .overwrite([])
     
     @Published var state: ContactInteractorState = .fetchingContacts
     
-    var contactsPublisher: AnyPublisher<[any Contactable], FollowUpError> {
+    var contactsPublisher: AnyPublisher<ContactSignal, FollowUpError> {
         $contacts.setFailureType(to: FollowUpError.self).eraseToAnyPublisher()
     }
 
@@ -35,11 +35,11 @@ class MockContactsInteractor: ContactsInteracting, ObservableObject {
         addToContactAmount: Int = 10
     ) {
         self.addToContactAmount = addToContactAmount
-        self.contacts = (0...addToContactAmount).map { _ in MockedContact() }
+        self.contacts = .overwrite((0...addToContactAmount).map { _ in MockedContact() })
     }
 
     func fetchContacts() {
-        self.contacts.append(contentsOf: generateContacts(withCount: 10))
+//        self.contacts.append(contentsOf: generateContacts(withCount: 10))
     }
     
     func updateContactInStore(withCNContactID ID: ContactID) {

--- a/FollowUp/Model/Contactable.swift
+++ b/FollowUp/Model/Contactable.swift
@@ -80,6 +80,8 @@ class Contact: Object, ObjectKeyIdentifiable, Contactable, Identifiable {
     @Persisted var _thumbnailImageData: Data?
     @Persisted var email: String?
     @Persisted var createDate: Date
+    @Persisted var note: String?
+
     
     // MARK: - Protocol Conformance
     var thumbnailImage: UIImage? {
@@ -100,7 +102,6 @@ class Contact: Object, ObjectKeyIdentifiable, Contactable, Identifiable {
     @Persisted var followUps: Int = 0 { didSet { lastFollowedUp = .now } }
     @Persisted var lastFollowedUp: Date? { didSet { lastInteractedWith = .now } }
     @Persisted var highlighted: Bool = false { didSet { lastInteractedWith = .now } }
-    @Persisted var note: String? { didSet { lastInteractedWith = .now } }
     @Persisted var followUpFrequency: FollowUpFrequency? { didSet { lastInteractedWith = .now } }
     
     // TODO: - Ensure that this is reworked to act as a computed property that depends on the 'followUpFrequency' object.
@@ -177,6 +178,34 @@ class Contact: Object, ObjectKeyIdentifiable, Contactable, Identifiable {
     
 }
 
+// MARK: - Convenience Methods
+extension Contact {
+    func updateNonInteractiveProperties(fromContact contact: any Contactable) {
+        self.name = contact.name
+        self.phoneNumber = contact.phoneNumber
+        self.note = contact.note
+        self.email = contact.email
+    }
+    
+    /// Creates a new version of the contact with updated non-interactive properties from the user's Address Book
+    func updatedWithNonInteractiveProperties(fromContact contact: any Contactable) -> any Contactable {
+        Contact(
+            contactID: self.id,
+            name: contact.name,
+            phoneNumber: contact.phoneNumber,
+            email: contact.email,
+            thumbnailImage: contact.thumbnailImage,
+            note: contact.note, 
+            followUps: self.followUps,
+            createDate: self.createDate,
+            lastFollowedUp: self.lastFollowedUp,
+            highlighted: self.highlighted,
+            containedInFollowUps: self.containedInFollowUps,
+            lastInteractedWith: self.lastInteractedWith
+        )
+    }
+}
+
 // MARK: - Convenience Initialisers and Conversions
 extension Contact {
     convenience init(from contact: CNContact){
@@ -222,7 +251,7 @@ extension Contact {
 // MARK: - Conversion to Concrete type Convenience
 extension Contactable {
     var concrete: Contact {
-        Contact.init(from: self)
+        (self as? Contact) ?? Contact.init(from: self)
     }
 }
 

--- a/FollowUp/Model/Contactable.swift
+++ b/FollowUp/Model/Contactable.swift
@@ -178,34 +178,6 @@ class Contact: Object, ObjectKeyIdentifiable, Contactable, Identifiable {
     
 }
 
-// MARK: - Convenience Methods
-extension Contact {
-    func updateNonInteractiveProperties(fromContact contact: any Contactable) {
-        self.name = contact.name
-        self.phoneNumber = contact.phoneNumber
-        self.note = contact.note
-        self.email = contact.email
-    }
-    
-    /// Creates a new version of the contact with updated non-interactive properties from the user's Address Book
-    func updatedWithNonInteractiveProperties(fromContact contact: any Contactable) -> any Contactable {
-        Contact(
-            contactID: self.id,
-            name: contact.name,
-            phoneNumber: contact.phoneNumber,
-            email: contact.email,
-            thumbnailImage: contact.thumbnailImage,
-            note: contact.note, 
-            followUps: self.followUps,
-            createDate: self.createDate,
-            lastFollowedUp: self.lastFollowedUp,
-            highlighted: self.highlighted,
-            containedInFollowUps: self.containedInFollowUps,
-            lastInteractedWith: self.lastInteractedWith
-        )
-    }
-}
-
 // MARK: - Convenience Initialisers and Conversions
 extension Contact {
     convenience init(from contact: CNContact){

--- a/FollowUp/Model/Error/FollowUpError.swift
+++ b/FollowUp/Model/Error/FollowUpError.swift
@@ -13,6 +13,7 @@ enum FollowUpError: LocalizedError {
     // MARK: - Contacts Interactor
     case requestAccessError(Error?)
     case cnContactQueryError(Error?)
+    case couldNotFindContact
     
     var id: String { self.title }
     
@@ -20,6 +21,7 @@ enum FollowUpError: LocalizedError {
         switch self {
         case .cnContactQueryError: return "Error Fetching Contacts"
         case .requestAccessError: return "Error Accessing Contacts"
+        case .couldNotFindContact: return "Could Not Find Contact"
         }
     }
     
@@ -27,6 +29,7 @@ enum FollowUpError: LocalizedError {
         switch self {
         case let .cnContactQueryError(error): return error?.localizedDescription ?? ""
         case let .requestAccessError(error): return error?.localizedDescription ?? ""
+        case .couldNotFindContact: return title
         }
     }
     
@@ -36,6 +39,7 @@ enum FollowUpError: LocalizedError {
         switch self {
         case .cnContactQueryError: return "Please send app feedback."
         case .requestAccessError: return "Ensure that the app has access to your contacts."
+        case .couldNotFindContact: return "Please send app feedback."
         }
     }
 }

--- a/FollowUp/Model/FollowUpManager.swift
+++ b/FollowUp/Model/FollowUpManager.swift
@@ -62,8 +62,13 @@ final class FollowUpManager: ObservableObject {
                         self.error = error
                     }
                 },
-                receiveValue: { newContacts in
-                self.store.updateWithFetchedContacts(newContacts)
+                receiveValue: { contactSignal in
+                    switch contactSignal {
+                    case let .overwrite(newContacts):
+                        self.store.updateWithFetchedContacts(newContacts)
+                    case let .updateAndMerge(contact):
+                        self.store.updateAndMerge(contact: contact)
+                    }
             })
             .store(in: &self.subscriptions)
     }

--- a/FollowUp/Model/FollowUpStore.swift
+++ b/FollowUp/Model/FollowUpStore.swift
@@ -185,9 +185,6 @@ class FollowUpStore: FollowUpStoring, ObservableObject {
             // TODO: We should always start with the last interacted with contact, and then update all the other values (e.g. name, email, phone number, etc).
             (first.lastInteractedWith ?? .distantPast) > (second.lastInteractedWith ?? .distantPast) ? first : second
         }
-//        self.contactsDictionary.merge(contacts.mappedToDictionary(by: \.id)) { current, new in
-//            current.concrete.updatedWithNonInteractiveProperties(fromContact: new)
-//        }
     }
     
     func numberOfContacts(_ searchPredicate: NewContactSearchPredicate, completion: @escaping (Int?) -> Void) {

--- a/FollowUp/Model/FollowUpStore.swift
+++ b/FollowUp/Model/FollowUpStore.swift
@@ -157,6 +157,7 @@ class FollowUpStore: FollowUpStoring, ObservableObject {
                 updatedContact.thumbnailImage = contact.thumbnailImage
                 updatedContact.email = contact.email
                 updatedContact.note = contact.note
+                updatedContact.lastInteractedWith = .now
             }
         } catch {
             Log.error("Could not update Realm copy of Contact \(contact.id): (\(contact.name) due to error: \(error.localizedDescription)")

--- a/FollowUp/Model/FollowUpStore.swift
+++ b/FollowUp/Model/FollowUpStore.swift
@@ -180,9 +180,14 @@ class FollowUpStore: FollowUpStoring, ObservableObject {
     // prefer the contacts which have a newer 'lastInteractedWith', because that doesn't really work. We need a way of updating the details on every single contact with the details that we receive from the signal. We should assume that the details received for nonInteractivProperties are
     // always correct.
     func mergeWithContactsDictionary(contacts: [any Contactable]) {
-        self.contactsDictionary.merge(contacts.mappedToDictionary(by: \.id)) { current, new in
-            current.concrete.updatedWithNonInteractiveProperties(fromContact: new)
+        self.contactsDictionary.merge(contacts.mappedToDictionary(by: \.id)) { first, second in
+            // Check to see when we last interacted with a contact. We use the most recently interacted with version.
+            // TODO: We should always start with the last interacted with contact, and then update all the other values (e.g. name, email, phone number, etc).
+            (first.lastInteractedWith ?? .distantPast) > (second.lastInteractedWith ?? .distantPast) ? first : second
         }
+//        self.contactsDictionary.merge(contacts.mappedToDictionary(by: \.id)) { current, new in
+//            current.concrete.updatedWithNonInteractiveProperties(fromContact: new)
+//        }
     }
     
     func numberOfContacts(_ searchPredicate: NewContactSearchPredicate, completion: @escaping (Int?) -> Void) {

--- a/FollowUp/Views/Button/CircularButton.swift
+++ b/FollowUp/Views/Button/CircularButton.swift
@@ -24,6 +24,7 @@ struct CircularButton: View {
             Image(icon: icon)
                 .resizable()
                 .renderingMode(.template)
+                .aspectRatio(contentMode: .fit)
                 .frame(width: 15, height: 15, alignment: .center)
         })
             .accentColor(accentColour)

--- a/FollowUp/Views/ContactSheet/ContactSheetView.swift
+++ b/FollowUp/Views/ContactSheet/ContactSheetView.swift
@@ -193,9 +193,14 @@ struct ContactSheetView: View {
     var body: some View {
         variableContent
             .sheet(item: $nativeContactSheetID, onDismiss: {
-                self.updateCurrentContact()
+               
+                // When the user does not edit the contact using 'Edit', the sheet appears to dismiss before the change to the contact is actually applied. We add a small delay to ensure the change is made so that the newly fetched contact contains the newest data.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
+                    self.updateCurrentContact()
+                })
             }, content: {_ in
                 NativeContactView(contactID: contact.id)
+                    .ignoresSafeArea(.all, edges: .bottom)
             })
     }
     
@@ -224,6 +229,6 @@ struct ContactSheetView_Previews: PreviewProvider {
                 .preferredColorScheme(.dark)
         }
         .environmentObject(FollowUpManager())
-        .environmentObject(FollowUpStore.mocked())
+//        .environmentObject(FollowUpStore.mocked())
     }
 }

--- a/FollowUp/Views/ContactSheet/NativeContactView.swift
+++ b/FollowUp/Views/ContactSheet/NativeContactView.swift
@@ -1,0 +1,81 @@
+//
+//  NativeContactView.swift
+//  FollowUp
+//
+//  Created by Aaron Baw on 06/09/2024.
+//
+
+import SwiftUI
+import Contacts
+import ContactsUI
+
+struct NativeContactView: UIViewControllerRepresentable {
+    
+    let contactID: String
+    
+    @Environment(\.presentationMode) var presentationMode // Environment variable for dismissing SwiftUI view
+
+    class Coordinator: NSObject {
+        var parent: NativeContactView
+
+        init(_ parent: NativeContactView) {
+            self.parent = parent
+        }
+
+        // Selector method for dismiss button action
+        @objc func dismissViewController() {
+            parent.presentationMode.wrappedValue.dismiss() // Dismiss the SwiftUI view
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+         return Coordinator(self)
+     }
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        // Create a CNContactStore instance to fetch the contact
+        let store = CNContactStore()
+
+        // Use descriptorForRequiredKeys to fetch all required keys
+        let keys = CNContactViewController.descriptorForRequiredKeys()
+
+        do {
+            // Fetch the contact by ID with the required keys
+            let contact = try store.unifiedContact(withIdentifier: contactID, keysToFetch: [keys])
+
+            // Create a CNContactViewController with the fetched contact
+            let contactViewController = CNContactViewController(for: contact)
+            contactViewController.allowsEditing = true // Set to true if you want to allow editing
+            
+            contactViewController.modalPresentationStyle = .automatic
+            contactViewController.viewRespectsSystemMinimumLayoutMargins = true
+            
+            contactViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+                title: "Close",
+                style: .done,
+                target: context.coordinator,
+                action: #selector(context.coordinator.dismissViewController)
+            )
+            
+            
+            let navigationController = UINavigationController(rootViewController: contactViewController)
+            navigationController.modalPresentationStyle = .pageSheet
+            navigationController.navigationBar.prefersLargeTitles = true // If you want a large title appearance
+            
+            return navigationController
+        } catch {
+            print("Failed to fetch contact with ID \(contactID): \(error)")
+            return UINavigationController()
+        }
+    }
+
+    
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+        // No need to update the view controller here
+    }
+    
+}
+
+#Preview {
+    NativeContactView(contactID: "1")
+}


### PR DESCRIPTION
- Adds Contact Edit Button so that users can edit contact details using native contact UI straight from inside FollowUp, by opening a native contact modal when the contact edit button is pressed.

| New Button | Modal Opened |
|:-:|:-:|
| ![Simulator Screenshot - iPhone 16 Pro - 2024-09-27 at 23 52 17](https://github.com/user-attachments/assets/97ed828a-8b16-4f8a-891f-f35c8e6d6323) | ![Simulator Screenshot - iPhone 16 Pro - 2024-09-27 at 23 52 29](https://github.com/user-attachments/assets/c0a8a4ec-1956-483e-af98-13d4414fa8d1) |

